### PR TITLE
Add RepoDocs page, which demos @Leila's fresh Markdown docs repo or a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "dependencies": {
     "@gridsome/source-graphql": "^0.1.0",
     "@gridsome/vue-remark": "^0.1.10",
+    "babel-runtime": "^6.26.0",
     "buefy": "^0.8.13",
-    "gridsome": "^0.7.0"
+    "gridsome": "^0.7.0",
+    "vue-markdown": "^2.2.4"
   },
   "devDependencies": {
     "lerna": "^3.20.2",

--- a/src/components/Nav.vue
+++ b/src/components/Nav.vue
@@ -14,6 +14,7 @@
       <b-navbar-item href="/" tag="router-link" :to="{ path: '/' }">Home</b-navbar-item>
       <b-navbar-item href="documentation">Documentation</b-navbar-item>
       <b-navbar-item href="demo-connect">Demo Connect</b-navbar-item>
+      <b-navbar-item href="repo-docs">Repo Docs</b-navbar-item>
       <b-navbar-dropdown label="Info">
         <b-navbar-item href="about">About</b-navbar-item>
         <b-navbar-item href="contact">Contact</b-navbar-item>

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -42,19 +42,31 @@
     padding-right: 20px;
   }
   /* these next because Buefy clears all expected formats -- probably need to define more, as needed */
-  h1, h2, h3 {
+  h1, h2, h3, h4 {
     color: darkblue;
     font-weight: bold;
-    display: block;
+    margin-bottom: 1em;
   }
   h1 {
     font-size: x-large;
-    line-height: 2em;
   }
   h2 {
     font-size: large;
   }
   h3 {
     font-size: medium;
+  }
+  h4 {
+    font-size: smaller;
+  }
+  ul {
+    list-style: disc;
+    margin-left: 2em;
+  }
+  li {
+    margin-bottom: 1em;
+  }
+  p {
+    margin-bottom: 1em;
   }
 </style>

--- a/src/pages/DemoConnect.vue
+++ b/src/pages/DemoConnect.vue
@@ -3,7 +3,7 @@
     <h1>Demo Connect</h1>
     <p>Demonstrate a single connection to GitHub API -- the
       actual app will need to dynamically manage multiple connections,
-      one at a time, for each tool repo.</p>
+      one at a time, for each participating Github account.</p>
     <div class="query-content">
       <div v-if="$page">
         <h2>Repo owner = {{ $page.gitapi.repos.name }}</h2>

--- a/src/pages/RepoDocs.vue
+++ b/src/pages/RepoDocs.vue
@@ -1,0 +1,106 @@
+<template>
+  <Layout>
+    <h1>Repo Docs</h1>
+    <p>Showing expected standard '01-title.md' descriptions, on a single connection to GitHub API,
+      and for as many repos have the standard `docs/ES/` folder arrangement so we see ES documents.</p>
+    <p>Display formatting is rough, and I may want to go a better means than VueMarkdown, but it gives a first demo.
+      A master-detail layout to view one listed doc at a time may or not be needed for performance
+      and feel. The actual app will need to dynamically manage multiple connections, one at a time,
+      for each participating Github account.</p>
+    <div class="query-content">
+      <div v-if="$page">
+        <h2>Repo owner is {{ $page.gitapi.repos.name }}</h2>
+        <div class="repo-list" v-for="node in $page.gitapi.repos.repositories.nodes" v-if="node.object">
+          <p>Repo name is {{ node.name }}</p>
+          <VueMarkdown :source="node.object.text"
+                       :anchorAttributes="anchorParts"
+                       :prerender="cleanFormatMarkdown"/>
+        </div>
+      </div>
+      <div v-else>
+        <h2>No data yet...</h2>
+      </div>
+    </div>
+
+  </Layout>
+</template>
+
+<script>
+import VueMarkdown from 'vue-markdown'
+
+export default {
+  metaInfo: {
+    title: 'Demo Connect'
+  },
+  data: function () {
+    return {
+      anchorParts: {
+        target: '_blank',
+        rel: 'noreferrer noopener'
+      },
+      numberRepos: 99
+    }
+  },
+  mounted () {
+    // this.tabTargetLinks ();
+  },
+  methods: {
+    cleanFormatMarkdown (lines) {
+      // in case we have other operations to do, like properly
+      // *todo* formatting included [name](url) links if VueMarkdown doesn't???
+      // *todo* but a more complete markdown converter may be appearing on the horizon.
+      return this.stripFrontMatter(lines)
+    },
+    stripFrontMatter: function (lines) {
+      // *todo* later some way that VueMarkdown handles this itself?
+      return lines.replace(/---\n.+---\n/gs, '')
+    }
+  },
+  components: { VueMarkdown }
+}
+</script>
+
+// this is hardwired, as api graphql requires a first: or last: value,
+// but I believe this isn't settable in Gridsome unless creating page
+// programatically, via createPage().
+<page-query>
+query RepoDocs {
+  gitapi {
+    repos: viewer {
+      name
+      repositories(last: 99) {
+        nodes {
+          name
+          nameWithOwner
+          updatedAt
+          url
+          object(expression: "master:docs/ES/01-Title.md") {
+            ... on GitApi_Blob {
+              commitUrl
+              text
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</page-query>
+
+<style>
+  .li {
+    margin-bottom: 1em !important;
+  }
+</style>
+
+<style scoped>
+  .query-content {
+    margin: 20px;
+    padding: 15px;
+    color: darkslategray;
+    background-color: beige;
+  }
+  .repo-list {
+    padding: 2px 10px;
+  }
+</style>


### PR DESCRIPTION
… fork, when you give a Github personal access token for that, in a form suggestive of what will come.'

It will actually preview any repos which have the docs folder and summary content in expected arrangement.

![repo-docs](https://user-images.githubusercontent.com/247945/77501987-c7e17980-6e16-11ea-846a-8f24af899092.png)
