### PR TITLE
A full info query now, using a fragment

### DIFF
--- a/src/pages/JoseConnect.vue
+++ b/src/pages/JoseConnect.vue
@@ -10,7 +10,7 @@
             <h2>Repo name is {{ node.name }}</h2>
             <h1>Documents</h1>
             <!-- N.b. the test for folder.lang !== img can go out to assure, once Vuex cleans the tree -->
-            <div class="folder" v-if="folder.lang !== 'img'" v-for="folder in node.docs.folders">
+            <div class="folder" v-if="folder && folder.lang !== 'img'" v-for="folder in node.docs.folders">
               <h2>Language: {{ folder.lang }}</h2>
               <div class="file" v-for="file in folder.contents.files">
                 <h3>{{ file.name }}</h3>
@@ -46,11 +46,12 @@ export default {
     }
   },
   mounted () {
+    // these are just dev debug possibilities, soon to go as not now needed
     // console.log ('results: ' + JSON.stringify(this.$page))
-    console.log ('results: ' +
-      JSON.stringify(this.$page.gitapi.repos.repositories.nodes[4].docs.folders[0].lang))
-    console.log ('results: ' +
-      JSON.stringify(this.$page.gitapi.repos.repositories.nodes[4].docs.folders[0].folder.files[0]))
+    // console.log ('results: ' +
+    //   JSON.stringify(this.$page.gitapi.repos.repositories.nodes[4].docs.folders[0].lang))
+    // console.log ('results: ' +
+    //   JSON.stringify(this.$page.gitapi.repos.repositories.nodes[4].docs.folders[0].folder.files[0]))
   }
 }
 </script>
@@ -58,22 +59,6 @@ export default {
 // this is full-results query, for everything it seems we need.
 // images are duplicate-listed under docs files, but unavoidable and cheap
 <page-query>
-
-fragment FolderInfo on GitApi_TreeEntry {
-    contents: object {
-      ... on GitApi_Tree {
-        files: entries {
-          name
-          object {
-            ...on GitApi_Blob {
-              isBinary
-              text
-            }
-          }
-        }
-      }
-    }
-  }
 
   query Jurra3 {
   gitapi{
@@ -109,6 +94,22 @@ fragment FolderInfo on GitApi_TreeEntry {
     }
   }
 }
+
+fragment FolderInfo on GitApi_TreeEntry {
+    contents: object {
+      ... on GitApi_Tree {
+        files: entries {
+          name
+          object {
+            ...on GitApi_Blob {
+              isBinary
+              text
+            }
+          }
+        }
+      }
+    }
+  }
 
 </page-query>
 


### PR DESCRIPTION
to dig out both language and files in one go. Simple formatting suits this as a test-only page, while showing all. The folder.contents is necessary because of the nesting of the original GitApi schema.