### PR TITLE
Pick up the fix which makes Vuetify page layouts behave,

### DIFF
--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,9 +1,11 @@
 <template>
   <v-app>
-      <Nav/>
-    
+    <Nav/>
+    <v-content>
+      <v-container>
         <slot/>
- 
+      </v-container>
+    </v-content>
   </v-app>
 </template>
 

--- a/src/pages/JoseConnect.vue
+++ b/src/pages/JoseConnect.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout>
-    <h1 align="center">#HardwareCombats.covid</h1>
+    <h1 class="horiz-center">#HardwareCombats.covid</h1>
     <v-container grid-list-lg fluid>
       <v-layout row wrap>
         <v-flex xs12 md3 v-for="repo in $page.gitapi.organization.repositories.nodes" :key="repo.name">
@@ -57,27 +57,23 @@ export default {
 // but I believe this isn't settable in Gridsome unless creating page
 // programatically, via createPage()
 <page-query>
-  query Jurra1 {
+  query Jurra3 {
   gitapi{
-    organization(login:"CombatCovid"){
+    repos: organization(login:"CombatCovid"){
       repositories(first:50){
-        nodes{
+        nodes {
           name
           nameWithOwner
-          description
           docs: object(expression: "master:docs") {
             ... on GitApi_Tree {
-              entries {
-                name
+              folders: entries {
+                lang: name
+                ... FolderInfo
               }
-            }
-            ... on GitApi_Blob {
-              text
             }
            }
            images: object(expression: "master:docs/img") {
              ... on GitApi_Tree {
-#             ... on Tree {
                entries {
                  name
                }
@@ -85,7 +81,6 @@ export default {
            }
            srcs: object(expression: "master:src") {
              ... on GitApi_Tree {
-#             ... on Tree {
                entries {
                  name
                }
@@ -97,7 +92,25 @@ export default {
   }
 }
 
+fragment FolderInfo on GitApi_TreeEntry {
+    contents: object {
+      ... on GitApi_Tree {
+        files: entries {
+          name
+          object {
+            ...on GitApi_Blob {
+              isBinary
+              text
+            }
+          }
+        }
+      }
+    }
+  }
 </page-query>
 
 <style scoped>
+  .horiz-center {
+    margin: 0 auto;
+  }
 </style>

--- a/src/pages/JoseConnect.vue
+++ b/src/pages/JoseConnect.vue
@@ -58,8 +58,8 @@ export default {
 // programatically, via createPage()
 <page-query>
   query Jurra3 {
-  gitapi{
-    repos: organization(login:"CombatCovid"){
+  gitapi {
+    organization(login:"CombatCovid"){
       repositories(first:50){
         nodes {
           name
@@ -112,5 +112,6 @@ fragment FolderInfo on GitApi_TreeEntry {
 <style scoped>
   .horiz-center {
     margin: 0 auto;
+    text-align: center;
   }
 </style>

--- a/src/pages/JoseConnect.vue
+++ b/src/pages/JoseConnect.vue
@@ -1,27 +1,26 @@
 <template>
-  <Layout style="padding-top:70px;">
-  <v-container grid-list-lg fluid>
-    <!-- <h1 align="center">#HardwareCombats.covid</h1> -->
-
-    <v-layout row wrap>
-      <v-flex xs12 md3 v-for="repo in $page.gitapi.organization.repositories.nodes" :key="repo.name">
-        <v-card  hover min-height="350px" max-height="350px">
-          <v-img v-if="repo.images !== null"
-            p-5 class="white--text align-end" height="200px" 
-            :src="getImgUrl(repo.nameWithOwner, repo.images.entries[0].name)"
-          >  
-          </v-img>
-          <v-img v-else
-            p-5 class="white--text align-end" height="200px" 
-            src="https://www.stleos.uq.edu.au/wp-content/uploads/2016/08/image-placeholder.png"
-          >  
-          </v-img>
-          <v-card-title v-text="repo.name"></v-card-title>
-          <v-card-subtitle v-text="repo.description"></v-card-subtitle>
-        </v-card>
-      </v-flex>
-    </v-layout>
-  </v-container>
+  <Layout>
+    <h1 align="center">#HardwareCombats.covid</h1>
+    <v-container grid-list-lg fluid>
+      <v-layout row wrap>
+        <v-flex xs12 md3 v-for="repo in $page.gitapi.organization.repositories.nodes" :key="repo.name">
+          <v-card hover min-height="350px" max-height="350px">
+            <v-img v-if="repo.images !== null"
+                   p-5 class="white--text align-end" height="200px"
+                   :src="getImgUrl(repo.nameWithOwner, repo.images.entries[0].name)"
+            >
+            </v-img>
+            <v-img v-else
+                   p-5 class="white--text align-end" height="200px"
+                   src="https://www.stleos.uq.edu.au/wp-content/uploads/2016/08/image-placeholder.png"
+            >
+            </v-img>
+            <v-card-title v-text="repo.name"></v-card-title>
+            <v-card-subtitle v-text="repo.description"></v-card-subtitle>
+          </v-card>
+        </v-flex>
+      </v-layout>
+    </v-container>
   </Layout>
 </template>
 


### PR DESCRIPTION
have intended appearance; especially, not hide their tops and titles under the menubar.
Tweak JoseConnect.vue to match, and restore its current title.